### PR TITLE
Changed text orientation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -147,7 +147,7 @@ img.modal-tyto-logo {
 .tyto-item-content {
   min-height: 50px;
   margin: 10px 0 0 0;
-  text-align: center;
+  text-align: left;
   font-size: 0.85em;
   color: #777;
   overflow: hidden;
@@ -168,7 +168,7 @@ img.modal-tyto-logo {
   font-size: 1.25em;
   overflow: hidden;
   text-overflow: ellipsis;
-  text-align: center;
+  text-align: left;
 }
 .tyto-item .tyto-item-header .action-icons {
   position: absolute;


### PR DESCRIPTION
Left-alignment on `.tyto-item-header h6` and `.tyto-item-content` looks cleaner to me than center-alignment.
