### PR TITLE
Resolve #53 by adding OS check for template compilation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ var gulp       = require('gulp'),
   source       = require('vinyl-source-stream'),
   buffer       = require('vinyl-buffer'),
   fs           = require('fs'),
+  os           = require('os'),
   browserSync  = require('browser-sync'),
   gConfig      = require('./gulp-config'),
   pluginOpts   = gConfig.pluginOpts,
@@ -87,7 +88,7 @@ gulp.task('tmpl:compile', function(){
     .pipe(plugins.jade(pluginOpts.jade))
     .pipe(plugins.template({
       name: 'templates.js',
-      base: 'src/jade/templates/',
+      base: (os.platform() === 'win32') ? 'src\\jade\\templates\\': 'src/jade/templates/',
       variable: 'module.exports'
     }))
     .pipe(gulp.dest(destinations.templates));


### PR DESCRIPTION
Add simple OS check for Windows using `os`. 

Maybe worth investigating `gulp-template-store`.

@jh3y