### PR TITLE
#53 Revert os check and use updated gulp-template-store

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,6 @@ var gulp       = require('gulp'),
   source       = require('vinyl-source-stream'),
   buffer       = require('vinyl-buffer'),
   fs           = require('fs'),
-  os           = require('os'),
   browserSync  = require('browser-sync'),
   gConfig      = require('./gulp-config'),
   pluginOpts   = gConfig.pluginOpts,
@@ -88,7 +87,7 @@ gulp.task('tmpl:compile', function(){
     .pipe(plugins.jade(pluginOpts.jade))
     .pipe(plugins.template({
       name: 'templates.js',
-      base: (os.platform() === 'win32') ? 'src\\jade\\templates\\': 'src/jade/templates/',
+      base: 'src/jade/templates/',
       variable: 'module.exports'
     }))
     .pipe(gulp.dest(destinations.templates));

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gulp-size": "^1.2.1",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-stylus": "^2.0.1",
-    "gulp-template-store": "^1.0.0",
+    "gulp-template-store": "^1.1.1",
     "gulp-uglify": "^1.4.1",
     "gulp-util": "^3.0.4",
     "gulp-wrap": "^0.11.0",


### PR DESCRIPTION
Resolves #53 by reverting `os.platform()` check and updates `gulp-template-store` version being used.